### PR TITLE
Add Russian locale

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,20 @@
+ru:
+  errors:
+    messages:
+      in_between: "должен быть между %{min} и %{max}"
+      spoofed_media_type: "имеет содержимое, не соответствующее заявленному"
+
+  number:
+    human:
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            few: "Байта"
+            many: "Байт"
+            one: "Байт"
+            other: "Байта"
+          gb: "ГБ"
+          kb: "КБ"
+          mb: "МБ"
+          tb: "ТБ"


### PR DESCRIPTION
The units section's format has been copied from the rails-i18n locale
that can be found here:
https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ru.yml

In response to https://github.com/thoughtbot/paperclip-i18n/issues/1
